### PR TITLE
Miscellaneous optimisations and fixes

### DIFF
--- a/05_ca/README
+++ b/05_ca/README
@@ -1,5 +1,5 @@
 Compile with:
-nvcc main.cu -std=c++11 -default-stream per-thread -Wno-deprecated-gpu-targets -O2 -ltbb -Xcompiler -fopenmp -o ca
+nvcc main.cu -arch=sm_61 -std=c++11 -default-stream per-thread -Wno-deprecated-gpu-targets -O3 -ltbb -Xcompiler -fopenmp -o ca 
 
 Execute with: 
 ./ca -n 120 -s 8 -i ../input/parsed_ttbar50PU_1000evts.txt -j 32 -t 1000

--- a/05_ca/main.cu
+++ b/05_ca/main.cu
@@ -636,7 +636,7 @@ double start = omp_get_wtime();
                 dim3 numberOfBlocks_find(8, h_allEvents[i].numberOfRootLayerPairs);
 // KERNELS
 //        debug_input_data<<<1,1,0,streams[streamIndex]>>>(&d_events[streamIndex], &d_doublets[d_firstLayerPairInEvt], &d_layers[d_firstLayerInEvt],d_regionParams,  maxNumberOfHits );
-                kernel_create<<<numberOfBlocks_create,256,0,streams[gpuIndex][streamIndex]>>>(&d_events[gpuIndex][streamIndex], &d_doublets[gpuIndex][d_firstLayerPairInEvt],
+                kernel_create<<<numberOfBlocks_create,32,0,streams[gpuIndex][streamIndex]>>>(&d_events[gpuIndex][streamIndex], &d_doublets[gpuIndex][d_firstLayerPairInEvt],
                         &d_layers[gpuIndex][d_firstLayerInEvt], &device_theCells[gpuIndex][d_firstLayerPairInEvt*maxNumberOfDoublets],
                         &device_isOuterHitOfCell[gpuIndex][d_firstHitInEvent], &d_foundNtuplets[gpuIndex][streamIndex],d_regionParams[gpuIndex], maxNumberOfDoublets, maxNumberOfHits);
 
@@ -645,7 +645,7 @@ double start = omp_get_wtime();
 //                &d_layers[d_firstLayerInEvt], &device_theCells[d_firstLayerPairInEvt*maxNumberOfDoublets],
 //                &device_isOuterHitOfCell[d_firstHitInEvent], &d_foundNtuplets[streamIndex],
 //                d_regionParams, theThetaCut, thePhiCut,theHardPtCut,maxNumberOfDoublets, maxNumberOfHits);
-                kernel_connect<<<numberOfBlocks_connect,256,0,streams[gpuIndex][streamIndex]>>>(&d_events[gpuIndex][streamIndex],
+                kernel_connect<<<numberOfBlocks_connect,512,0,streams[gpuIndex][streamIndex]>>>(&d_events[gpuIndex][streamIndex],
                         &d_doublets[gpuIndex][d_firstLayerPairInEvt], &device_theCells[gpuIndex][d_firstLayerPairInEvt*maxNumberOfDoublets],
                         &device_isOuterHitOfCell[gpuIndex][d_firstHitInEvent], d_regionParams[gpuIndex], theThetaCut, thePhiCut,
                         theHardPtCut, maxNumberOfDoublets, maxNumberOfHits);
@@ -655,7 +655,7 @@ double start = omp_get_wtime();
 //                 d_regionParams, maxNumberOfDoublets, maxNumberOfHits);
 //        cudaMemsetAsync(&d_foundNtuplets[streamIndex], 0, sizeof(GPUSimpleVector<maxNumberOfQuadruplets, Quadruplet> ), streams[streamIndex]);
 
-                kernel_find_ntuplets<<<numberOfBlocks_find,256,0,streams[gpuIndex][streamIndex]>>>(&d_events[gpuIndex][streamIndex],
+                kernel_find_ntuplets<<<numberOfBlocks_find,1024,0,streams[gpuIndex][streamIndex]>>>(&d_events[gpuIndex][streamIndex],
                         &d_doublets[gpuIndex][d_firstLayerPairInEvt], &device_theCells[gpuIndex][d_firstLayerPairInEvt*maxNumberOfDoublets],
                         &d_foundNtuplets[gpuIndex][streamIndex],&d_rootLayerPairs[gpuIndex][maxNumberOfRootLayerPairs*streamIndex], 4 , maxNumberOfDoublets);
 

--- a/05_ca/main.cu
+++ b/05_ca/main.cu
@@ -18,7 +18,7 @@
 #include <thread>
 #include <vector>
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include <tbb/concurrent_queue.h>
 #include <omp.h>
 #include <tuple>
@@ -779,6 +779,20 @@ double stop = omp_get_wtime();
         std::cerr << std::endl;
     }
 #endif // defined(DEBUG) && defined(VERBOSE)
+
+#if defined(DEBUG) && defined(ASSERT)
+    for (std::size_t n = 0 ; n < nEvents ; ++n) {
+        assert(nQuadruplets[n].size() == numberOfIterations);
+        assert(nQuadruplets[n].size() > 0);
+        const auto ref = nQuadruplets[n][0];
+        for (std::size_t it = 0 ; it < numberOfIterations ; ++it) {
+            if (nQuadruplets[n][it] != ref) {
+                std::cerr << "Event " << n << ", it. " << it << ": expected " << ref << ", got " << nQuadruplets[n][it] << " instead" << std::endl << std::flush;
+            }
+            assert(nQuadruplets[n][it] == ref);
+        }
+    }
+#endif // defined(DEBUG) && defined(ASSERT)
 
     std::cout << "Summary: " << std::endl;
     unsigned int processedByGPU = 0;


### PR DESCRIPTION
Summary of changes:
----------------------------

- Compile with `-arch=sm_61` on Pascal GPUs (update `README`) → +15%
- Manage the CUDA streams using a TBB concurrent queue (instead of round-robin) to avoid starving them → +10%.
- Tune the grid and thread block dimensions to maximize performance → +45%.
- Add various debug flags (`DEBUG`, `ASSERT`, `VERBOSE`) for checking the results.
- Fix a bug where memory was copied from multiple GPUs to the same host buffer.